### PR TITLE
Fix passenger JSON serialization and aircraft airport association issues

### DIFF
--- a/src/main/java/com/keyin/airportapi/aircraft/Aircraft.java
+++ b/src/main/java/com/keyin/airportapi/aircraft/Aircraft.java
@@ -21,8 +21,7 @@ public class Aircraft {
     @JsonIgnore
     private List<Passenger> passengers;
 
-    @ManyToMany
-    @JsonIgnore
+    @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(
             name = "aircraft_airports",
             joinColumns = @JoinColumn(name = "aircraft_id"),

--- a/src/main/java/com/keyin/airportapi/aircraft/AircraftRepository.java
+++ b/src/main/java/com/keyin/airportapi/aircraft/AircraftRepository.java
@@ -1,11 +1,17 @@
 package com.keyin.airportapi.aircraft;
 
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
 import java.util.List;
+import java.util.Optional;
 
-public interface AircraftRepository extends CrudRepository<Aircraft, Long> {
+public interface AircraftRepository extends JpaRepository<Aircraft, Long> {
+
     @Query("SELECT a FROM Aircraft a JOIN a.passengers p WHERE p.id = :passengerId")
-    List<Aircraft> findAircraftByPassengerId(Long passengerId);
-}
+    List<Aircraft> findAircraftByPassengerId(@Param("passengerId") Long passengerId);
 
+    @Query("SELECT a FROM Aircraft a LEFT JOIN FETCH a.airports WHERE a.aircraftId = :id")
+    Optional<Aircraft> findByIdWithAirports(@Param("id") Long id);
+}

--- a/src/main/java/com/keyin/airportapi/passenger/Passenger.java
+++ b/src/main/java/com/keyin/airportapi/passenger/Passenger.java
@@ -1,5 +1,6 @@
 package com.keyin.airportapi.passenger;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -82,6 +83,7 @@ public class Passenger {
         this.aircraft = aircraft;
     }
 
+    @JsonIgnore
     public Aircraft[] getAircraftList() {
         if (aircraft == null || aircraft.isEmpty()) {
             return new Aircraft[0];

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=airportapi
 
 spring.datasource.url=jdbc:mysql://localhost:3306/airport_api_db
 spring.datasource.username=root
-spring.datasource.password=Keyin202!
+spring.datasource.password=Skittles98
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update

--- a/src/test/java/com/keyin/airportapi/aircrafttest/AircraftServiceTest.java
+++ b/src/test/java/com/keyin/airportapi/aircrafttest/AircraftServiceTest.java
@@ -106,14 +106,18 @@ public class AircraftServiceTest {
     }
 
     @Test
-    @DisplayName("Should return null when updating non-existent aircraft")
-    public void testUpdateAircraft_NotFound() {
-        Aircraft updated = createTestAircraft(null, "Airbus A320", "WestJet", 180);
+    @DisplayName("Should throw RuntimeException when updating non-existent aircraft")
+    void testUpdateAircraft_NotFound() {
+        Long invalidId = 999L;
+        Aircraft updated = new Aircraft("Boeing 747", "Lufthansa", 300);
 
-        Mockito.when(aircraftRepository.findById(99L)).thenReturn(Optional.empty());
+        Mockito.when(aircraftRepository.findById(invalidId)).thenReturn(Optional.empty());
 
-        Aircraft result = aircraftService.updateAircraft(99L, updated);
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            aircraftService.updateAircraft(invalidId, updated);
+        });
 
-        assertNull(result);
+        assertEquals("Aircraft not found", exception.getMessage());
     }
+
 }


### PR DESCRIPTION
- Added @JsonIgnore to the getAircraftList() method in Passenger to prevent duplicate airport data in JSON responses, resolving serialization issues.
- Updated updateAircraft() method to convert the airports list to a mutable ArrayList before setting it, fixing UnsupportedOperationException caused by attempting to set an immutable list.
- Verified that aircraft can now be properly updated with associated airports and returned correctly via API.